### PR TITLE
Add Basic Healthcheck Endpoint (/healthcheck) for Monitoring

### DIFF
--- a/archive/documents/CheckList.md
+++ b/archive/documents/CheckList.md
@@ -18,8 +18,8 @@
 
 - [x] **Darkmode umgesetzt** (0-1 Punkt)
 - [AJ] **Aktuell verbundene Benutzer werden im Frontend angezeigt** (0-1 Punkt)
-- [NL] **„Schreibt gerade“ wird im Frontend angezeigt** (0-1 Punkt)
-- [NL] **Backend stellt REST-Endpunkt `/healthcheck` für Monitoring bereit (Status 200/OK)** (0-1 Punkt)
+- [x] **„Schreibt gerade“ wird im Frontend angezeigt** (0-1 Punkt)
+- [x] **Backend stellt REST-Endpunkt `/healthcheck` für Monitoring bereit (Status 200/OK)** (0-1 Punkt)
 
 ## Branching Strategie (0-2 Punkte) 1/2
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,6 +31,11 @@ app.use(express.static("client"));
 app.get("/", (req: Request, res: Response) => {
   res.sendFile(__dirname + "/client/index.html");
 });
+// Healthcheck endpoint
+app.get("/healthcheck", (req: Request, res: Response) => {
+  res.status(200).json({ status: "OK" });
+});
+
 // Initialize the websocket server
 initializeWebsocketServer(server);
 


### PR DESCRIPTION
This PR introduces a simple healthcheck endpoint (/healthcheck) to ensure that the backend is running and responsive. This endpoint returns a 200 OK status with a basic JSON response.